### PR TITLE
Feature/cvt functions

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,25 +5,31 @@ import random
 import numpy as np
 import cv2
 import skimage.transform as trans
-from utils import convert_image_np, normalize_transforms, rotatepoints, show_image
+from utils import (
+    convert_image_np,
+    rotatepoints,
+    show_image,
+    cvt_MToTheta,
+    cvt_ThetaToM,
+)
 
 
 """1. Load image and landmarks"""
-image = cv2.imread('1.png')
+image = cv2.imread("1.png")
 image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-h,w,c = image.shape
-src = np.genfromtxt('1.pts', skip_header=3, skip_footer=1)
-show_image(image,src)
+h, w, c = image.shape
+src = np.genfromtxt("1.pts", skip_header=3, skip_footer=1)
+show_image(image, src, 3)
 
 """2. augmentation(scale, rotation, translation)"""
-rot = random.randint(-50,50)
-dst = rotatepoints(src, [w/2, h/2], rot)
-left = min(dst[:,0])
-right = max(dst[:,0])
-top = min(dst[:,1])
-bot = max(dst[:,1])
+rot = random.randint(-50, 50)
+dst = rotatepoints(src, [w / 2, h / 2], rot)
+left = min(dst[:, 0])
+right = max(dst[:, 0])
+top = min(dst[:, 1])
+bot = max(dst[:, 1])
 dst -= [left, top]
-dst *= [w/(right-left), h/(bot-top)]
+dst *= [w / (right - left), h / (bot - top)]
 scale = random.uniform(0.8, 1.0)
 dst *= scale
 dx = random.uniform(-0.05, 0.05) * w
@@ -31,15 +37,15 @@ dy = random.uniform(-0.05, 0.05) * h
 dst += [dx, dy]
 
 """3.Warp image to cv_img using OpenCv"""
-tr = trans.estimate_transform('affine', src=src, dst=dst)
-M = tr.params[0:2,:]
+tr = trans.estimate_transform("affine", src=src, dst=dst)
+M = tr.params[0:2, :]
 cv_img = cv2.warpAffine(image, M, (image.shape[1], image.shape[0]))
-show_image(cv_img, dst)
+show_image(cv_img, dst, 4)
 
 """4.Affine Transformation Matrix to theta"""
-param = np.linalg.inv(tr.params)
-theta = normalize_transforms(param[0:2,:], w, h)
-
+theta = cvt_MToTheta(M, w, h)
+M2 = cvt_ThetaToM(theta, w, h)
+assert np.allclose(M, M2)
 
 """5.Warp image to tensor_img using grid_sample"""
 to_tensor = torchvision.transforms.ToTensor()
@@ -50,4 +56,4 @@ grid = F.affine_grid(theta, tensor_img.size())
 tensor_img = F.grid_sample(tensor_img, grid)
 tensor_img = tensor_img.squeeze(0)
 warp_img = convert_image_np(tensor_img)
-show_image(warp_img, dst)
+show_image(warp_img, dst, 5)

--- a/main.py
+++ b/main.py
@@ -57,3 +57,19 @@ tensor_img = F.grid_sample(tensor_img, grid)
 tensor_img = tensor_img.squeeze(0)
 warp_img = convert_image_np(tensor_img)
 show_image(warp_img, dst, 5)
+
+
+"""6. Draw cropped bounding box"""
+M3 = np.concatenate([M, np.zeros((1, 3))], axis=0).astype(np.float32)
+M3[-1, -1] = 1
+M3 = np.linalg.inv(M3)
+points = np.array([[0, 0], [w, 0], [w, h], [0, h]], dtype=np.float32).reshape(
+    (-1, 1, 2)
+)
+bbox = cv2.perspectiveTransform(points, M3)
+bbox = bbox.reshape((-1, 2))
+polygons = [np.int32(bbox)]
+img_with_box = image.copy()
+img_with_box = cv2.polylines(img_with_box, polygons, True, (0, 255, 255), 30)
+plt.imshow(img_with_box)
+plt.savefig("6.png")

--- a/utils.py
+++ b/utils.py
@@ -31,7 +31,23 @@ def get_N_inv(W, H):
 
 
 def cvt_MToTheta(M, w, h):
-    """M is shaped (2, 3) and np.ndarray"""
+    """convert affine warp matrix `M` compatible with `opencv.warpAffine` to `theta` matrix
+    compatible with `torch.F.affine_grid`
+
+    Parameters
+    ----------
+    M : np.ndarray
+        affine warp matrix shaped [2, 3]
+    w : int
+        width of image
+    h : int
+        height of image
+
+    Returns
+    -------
+    np.ndarray
+        theta tensor for `torch.F.affine_grid`, shaped [2, 3]
+    """
     M_aug = np.concatenate([M, np.zeros((1, 3))], axis=0)
     M_aug[-1, -1] = 1.0
     N = get_N(w, h)
@@ -42,7 +58,23 @@ def cvt_MToTheta(M, w, h):
 
 
 def cvt_ThetaToM(theta, w, h):
-    """theta is shaped (2, 3) and np.ndarray"""
+    """convert theta matrix compatible with `torch.F.affine_grid` to affine warp matrix `M`
+    compatible with `opencv.warpAffine`.
+
+    Parameters
+    ----------
+    theta : np.ndarray
+        theta tensor for `torch.F.affine_grid`, shaped [2, 3]
+    w : int
+        width of image
+    h : int
+        height of image
+
+    Returns
+    -------
+    np.ndarray
+        theta tensor for `torch.F.affine_grid`, shaped [2, 3]
+    """
     theta_aug = np.concatenate([theta, np.zeros((1, 3))], axis=0)
     theta_aug[-1, -1] = 1.0
     N = get_N(w, h)

--- a/utils.py
+++ b/utils.py
@@ -6,29 +6,51 @@ import matplotlib.pyplot as plt
 def convert_image_np(inp):
     """Convert a Tensor to numpy image."""
     inp = inp.numpy().transpose((1, 2, 0))
-    inp = (inp*255).astype(np.uint8)
+    inp = (inp * 255).astype(np.uint8)
     return inp
 
-# def normalize_transforms(transforms, H,W):
-#     transforms[0,0] = transforms[0,0]
-#     transforms[0,1] = transforms[0,1]*W/H
-#     transforms[0,2] = transforms[0,2]*2/H + transforms[0,0] + transforms[0,1] - 1
-#
-#     transforms[1,0] = transforms[1,0]*H/W
-#     transforms[1,1] = transforms[1,1]
-#     transforms[1,2] = transforms[1,2]*2/W + transforms[1,0] + transforms[1,1] - 1
-#
-#     return transforms
-def normalize_transforms(transforms, W,H):
-    transforms[0,0] = transforms[0,0]
-    transforms[0,1] = transforms[0,1]*H/W
-    transforms[0,2] = transforms[0,2]*2/W + transforms[0,0] + transforms[0,1] - 1
 
-    transforms[1,0] = transforms[1,0]*W/H
-    transforms[1,1] = transforms[1,1]
-    transforms[1,2] = transforms[1,2]*2/H + transforms[1,0] + transforms[1,1] - 1
+def get_N(W, H):
+    """N that maps from unnormalized to normalized coordinates"""
+    N = np.zeros((3, 3), dtype=np.float64)
+    N[0, 0] = 2.0 / W
+    N[0, 1] = 0
+    N[1, 1] = 2.0 / H
+    N[1, 0] = 0
+    N[0, -1] = -1.0
+    N[1, -1] = -1.0
+    N[-1, -1] = 1.0
+    return N
 
-    return transforms
+
+def get_N_inv(W, H):
+    """N that maps from normalized to unnormalized coordinates"""
+    # TODO: do this analytically maybe?
+    N = get_N(W, H)
+    return np.linalg.inv(N)
+
+
+def cvt_MToTheta(M, w, h):
+    """M is shaped (2, 3) and np.ndarray"""
+    M_aug = np.concatenate([M, np.zeros((1, 3))], axis=0)
+    M_aug[-1, -1] = 1.0
+    N = get_N(w, h)
+    N_inv = get_N_inv(w, h)
+    theta = N @ M_aug @ N_inv
+    theta = np.linalg.inv(theta)
+    return theta[:2, :]
+
+
+def cvt_ThetaToM(theta, w, h):
+    """theta is shaped (2, 3) and np.ndarray"""
+    theta_aug = np.concatenate([theta, np.zeros((1, 3))], axis=0)
+    theta_aug[-1, -1] = 1.0
+    N = get_N(w, h)
+    N_inv = get_N_inv(w, h)
+    M = np.linalg.inv(theta_aug)
+    M = N_inv @ M @ N
+    return M[:2, :]
+
 
 def rotatepoints(landmarks, center, rot):
     center_coord = np.zeros_like(landmarks)
@@ -37,26 +59,101 @@ def rotatepoints(landmarks, center, rot):
 
     angle = math.radians(rot)
 
-    rot_matrix = np.array([[math.cos(angle), -1 * math.sin(angle)],
-                           [math.sin(angle), math.cos(angle)]])
+    rot_matrix = np.array(
+        [[math.cos(angle), -1 * math.sin(angle)], [math.sin(angle), math.cos(angle)]]
+    )
 
     rotated_coords = np.dot((landmarks - center_coord), rot_matrix) + center_coord
 
     return rotated_coords
 
-def show_image(image, landmarks):
+
+def show_image(image, landmarks, i):
     # print(image.shape)
-    fig = plt.figure(figsize=plt.figaspect(.5))
+    fig = plt.figure(figsize=plt.figaspect(0.5))
     ax = fig.add_subplot(1, 1, 1)
     ax.imshow(image)
-    ax.plot(landmarks[0:17, 0], landmarks[0:17, 1], marker='o', markersize=4, linestyle='-', color='w', lw=2)
-    ax.plot(landmarks[17:22, 0], landmarks[17:22, 1], marker='o', markersize=4, linestyle='-', color='w', lw=2)
-    ax.plot(landmarks[22:27, 0], landmarks[22:27, 1], marker='o', markersize=4, linestyle='-', color='w', lw=2)
-    ax.plot(landmarks[27:31, 0], landmarks[27:31, 1], marker='o', markersize=4, linestyle='-', color='w', lw=2)
-    ax.plot(landmarks[31:36, 0], landmarks[31:36, 1], marker='o', markersize=4, linestyle='-', color='w', lw=2)
-    ax.plot(landmarks[36:42, 0], landmarks[36:42, 1], marker='o', markersize=4, linestyle='-', color='w', lw=2)
-    ax.plot(landmarks[42:48, 0], landmarks[42:48, 1], marker='o', markersize=4, linestyle='-', color='w', lw=2)
-    ax.plot(landmarks[48:60, 0], landmarks[48:60, 1], marker='o', markersize=4, linestyle='-', color='w', lw=2)
-    ax.plot(landmarks[60:68, 0], landmarks[60:68, 1], marker='o', markersize=4, linestyle='-', color='w', lw=2)
-    ax.axis('off')
+    ax.plot(
+        landmarks[0:17, 0],
+        landmarks[0:17, 1],
+        marker="o",
+        markersize=4,
+        linestyle="-",
+        color="w",
+        lw=2,
+    )
+    ax.plot(
+        landmarks[17:22, 0],
+        landmarks[17:22, 1],
+        marker="o",
+        markersize=4,
+        linestyle="-",
+        color="w",
+        lw=2,
+    )
+    ax.plot(
+        landmarks[22:27, 0],
+        landmarks[22:27, 1],
+        marker="o",
+        markersize=4,
+        linestyle="-",
+        color="w",
+        lw=2,
+    )
+    ax.plot(
+        landmarks[27:31, 0],
+        landmarks[27:31, 1],
+        marker="o",
+        markersize=4,
+        linestyle="-",
+        color="w",
+        lw=2,
+    )
+    ax.plot(
+        landmarks[31:36, 0],
+        landmarks[31:36, 1],
+        marker="o",
+        markersize=4,
+        linestyle="-",
+        color="w",
+        lw=2,
+    )
+    ax.plot(
+        landmarks[36:42, 0],
+        landmarks[36:42, 1],
+        marker="o",
+        markersize=4,
+        linestyle="-",
+        color="w",
+        lw=2,
+    )
+    ax.plot(
+        landmarks[42:48, 0],
+        landmarks[42:48, 1],
+        marker="o",
+        markersize=4,
+        linestyle="-",
+        color="w",
+        lw=2,
+    )
+    ax.plot(
+        landmarks[48:60, 0],
+        landmarks[48:60, 1],
+        marker="o",
+        markersize=4,
+        linestyle="-",
+        color="w",
+        lw=2,
+    )
+    ax.plot(
+        landmarks[60:68, 0],
+        landmarks[60:68, 1],
+        marker="o",
+        markersize=4,
+        linestyle="-",
+        color="w",
+        lw=2,
+    )
+    ax.axis("off")
     plt.show()
+    plt.savefig(f"{i}.png")

--- a/utils.py
+++ b/utils.py
@@ -34,6 +34,10 @@ def cvt_MToTheta(M, w, h):
     """convert affine warp matrix `M` compatible with `opencv.warpAffine` to `theta` matrix
     compatible with `torch.F.affine_grid`
 
+    Note:
+    M works with `opencv.warpAffine`.
+    To transform a set of bounding box corner points using `opencv.perspectiveTransform`, M^-1 is required
+
     Parameters
     ----------
     M : np.ndarray
@@ -57,9 +61,13 @@ def cvt_MToTheta(M, w, h):
     return theta[:2, :]
 
 
-def cvt_ThetaToM(theta, w, h):
+def cvt_ThetaToM(theta, w, h, return_inv=False):
     """convert theta matrix compatible with `torch.F.affine_grid` to affine warp matrix `M`
     compatible with `opencv.warpAffine`.
+
+    Note:
+    M works with `opencv.warpAffine`.
+    To transform a set of bounding box corner points using `opencv.perspectiveTransform`, M^-1 is required
 
     Parameters
     ----------
@@ -69,11 +77,13 @@ def cvt_ThetaToM(theta, w, h):
         width of image
     h : int
         height of image
+    return_inv : False
+        return M^-1 instead of M.
 
     Returns
     -------
     np.ndarray
-        theta tensor for `torch.F.affine_grid`, shaped [2, 3]
+        affine warp matrix `M` shaped [2, 3]
     """
     theta_aug = np.concatenate([theta, np.zeros((1, 3))], axis=0)
     theta_aug[-1, -1] = 1.0
@@ -81,6 +91,9 @@ def cvt_ThetaToM(theta, w, h):
     N_inv = get_N_inv(w, h)
     M = np.linalg.inv(theta_aug)
     M = N_inv @ M @ N
+    if return_inv:
+        M_inv = np.linalg.inv(M)
+        return M_inv[:2, :]
     return M[:2, :]
 
 


### PR DESCRIPTION
Hi,

I was following the discussion in the pytorch forum https://discuss.pytorch.org/t/affine-transformation-matrix-paramters-conversion/19522/21

 and really liked your minimal example. However, it still was not clear how to convert back from `theta` to `M`, so I modified
 your example a little bit to allow seamless front and back conversion between `opencv` and `torch.F.affine_grid`.

I think this could be useful for other people as well, therefore I am making a PR.